### PR TITLE
Initial Ansible image creation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nathanwasson

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,13 @@
 name: "Build Image"
 
 on:
-  pull_request: {}
+  pull_request:
+    branches: [ "main" ]
+    types: [ opened, synchronize, reopened ]
+    paths: [ "Dockerfile", "bin/**" ]
   push:
-    branches:
-      - "main"
-  workflow_dispatch: {}
+    branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -42,7 +44,7 @@ jobs:
             # Latest for main branch
             type=raw,enable={{is_default_branch}},priority=1,value=latest
 
-      - uses: "docker/build-push-action@v5"
+      - uses: "docker/build-push-action@v6"
         with:
           context: "."
           platforms: "linux/amd64,linux/arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # hadolint ignore=DL3007
-FROM ghcr.io/spacelift-io/runner-terraform:latest AS spacelift
+FROM ghcr.io/spacelift-io/runner-ansible:latest AS spacelift
 
 USER root
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache tailscale
+RUN apk add --no-cache tailscale bash netcat-openbsd
 
+# Copy Tailscale integration scripts
 COPY bin/ /usr/local/bin/
 
 # Let tailscale/d use default socket location

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: docker-build
 docker-build:
 	DOCKER_BUILDKIT=1 docker build \
-	--tag ghcr.io/caius/spacelift-tailscale:dev \
+	--tag ghcr.io/nathanwasson/spacelift-tailscale-ansible:dev \
 	.


### PR DESCRIPTION
This PR turns this fork into a functional Ansible version of caius/spacelift-tailscale by building from Spacelift's runner-ansible instead of runner-terraform and adding bash to support `spacetail` script and `netcat-openbsd` to support Ansible SSH over SOCKS5 proxy.